### PR TITLE
bugfix: Fix webpack-pwa-manifest injection.

### DIFF
--- a/packages/the-react-scripts/internals/webpack/webpack.prod.js
+++ b/packages/the-react-scripts/internals/webpack/webpack.prod.js
@@ -94,9 +94,9 @@ module.exports = merge(require('./webpack.base'), {
       },
     }),
 
-    // ! Disabled as it requires ^v4.0.0-alpha version of html-webpack-plugin
-    // ! which kills webpack-pwa-manifest injection
-    // Uncomment this line once we have figured out how to use this without breaking manifest injection
+    // InlineChunkHtmlPlugin currently requires ^v4.0.0-alpha version of 
+    // html-webpack-plugin which kills webpack-pwa-manifest injection.
+    // Uncomment the next line and import utility when fix is found.
     // ! new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),
 
     // Put it in the end to capture all the HtmlWebpackPlugin's

--- a/packages/the-react-scripts/internals/webpack/webpack.prod.js
+++ b/packages/the-react-scripts/internals/webpack/webpack.prod.js
@@ -5,7 +5,6 @@ const OfflinePlugin = require('offline-plugin');
 const { HashedModuleIdsPlugin } = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-const InlineChunkHtmlPlugin = require('../../utils/InlineChunkHtmlPlugin');
 const paths = require('../paths');
 
 module.exports = merge(require('./webpack.base'), {
@@ -95,7 +94,10 @@ module.exports = merge(require('./webpack.base'), {
       },
     }),
 
-    new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),
+    // ! Disabled as it requires ^v4.0.0-alpha version of html-webpack-plugin
+    // ! which kills webpack-pwa-manifest injection
+    // Uncomment this line once we have figured out how to use this without breaking manifest injection
+    // ! new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),
 
     // Put it in the end to capture all the HtmlWebpackPlugin's
     // assets manipulations and do leak its manipulations to HtmlWebpackPlugin

--- a/packages/the-react-scripts/internals/webpack/webpack.prod.js
+++ b/packages/the-react-scripts/internals/webpack/webpack.prod.js
@@ -94,7 +94,7 @@ module.exports = merge(require('./webpack.base'), {
       },
     }),
 
-    // InlineChunkHtmlPlugin currently requires ^v4.0.0-alpha version of 
+    // InlineChunkHtmlPlugin currently requires ^v4.0.0-alpha version of
     // html-webpack-plugin which kills webpack-pwa-manifest injection.
     // Uncomment the next line and import utility when fix is found.
     // ! new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime~.+[.]js/]),

--- a/packages/the-react-scripts/package.json
+++ b/packages/the-react-scripts/package.json
@@ -83,7 +83,7 @@
     "globby": "9.2.0",
     "graphql-tag": "2.10.1",
     "html-loader": "0.5.5",
-    "html-webpack-plugin": "4.0.0-alpha.2",
+    "html-webpack-plugin": "3.2.0",
     "husky": "2.3.0",
     "identity-obj-proxy": "3.0.0",
     "immer": "3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2691,11 +2691,6 @@
   dependencies:
     csstype "^2.6.4"
 
-"@types/tapable@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
-  integrity sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==
-
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
@@ -7677,17 +7672,17 @@ html-tags@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-2.0.0.tgz#10b30a386085f43cede353cc8fa7cb0deeea668b"
   integrity sha1-ELMKOGCF9Dzt41PMj6fLDe7qZos=
 
-html-webpack-plugin@4.0.0-alpha.2:
-  version "4.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-alpha.2.tgz#7745967e389a57a098e26963f328ebe4c19b598d"
-  integrity sha512-tyvhjVpuGqD7QYHi1l1drMQTg5i+qRxpQEGbdnYFREgOKy7aFDf/ocQ/V1fuEDlQx7jV2zMap3Hj2nE9i5eGXw==
+html-webpack-plugin@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
+  integrity sha1-sBq71yOsqqeze2r0SS69oD2d03s=
   dependencies:
-    "@types/tapable" "1.0.2"
     html-minifier "^3.2.3"
-    loader-utils "^1.1.0"
-    lodash "^4.17.10"
+    loader-utils "^0.2.16"
+    lodash "^4.17.3"
     pretty-error "^2.0.2"
     tapable "^1.0.0"
+    toposort "^1.0.0"
     util.promisify "1.0.0"
 
 html-webpack-plugin@^4.0.0-beta.2:
@@ -9489,7 +9484,7 @@ loader-runner@^2.3.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@0.2.x:
+loader-utils@0.2.x, loader-utils@^0.2.16:
   version "0.2.17"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
   integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
@@ -9637,7 +9632,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.11, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
+lodash@4.17.11, lodash@^4.0.1, lodash@^4.1.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
@@ -14407,6 +14402,11 @@ toidentifier@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
+
+toposort@^1.0.0:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
+  integrity sha1-LmhELZ9k7HILjMieZEOsbKqVACk=
 
 toposort@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
Disable InlineChunkHtmlPlugin as it requires ^v4.0.0-alpha version of html-webpack-plugin which kills webpack-pwa-manifest injection.