### PR TITLE
feat(test-utils): Setup tests custom render.

### DIFF
--- a/packages/the-react-scripts/template/src/setupTests.ts
+++ b/packages/the-react-scripts/template/src/setupTests.ts
@@ -6,3 +6,13 @@ import 'jest-dom/extend-expect';
 import 'whatwg-fetch';
 import 'jest-canvas-mock';
 import 'jest-styled-components';
+
+window.matchMedia = jest.fn().mockImplementation(query => {
+  return {
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+  };
+});

--- a/packages/the-react-scripts/template/src/utils/test-utils.tsx
+++ b/packages/the-react-scripts/template/src/utils/test-utils.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react'
+import { AppProvider } from '@app/contexts';
+
+// TODO: Make customRender type-safe.
+const customRender = (ui: any, options?: any) =>
+  render(ui, { wrapper: AppProvider, ...options })
+
+// re-export everything
+export * from '@testing-library/react'
+
+// override render method
+export { customRender as render }


### PR DESCRIPTION
Extend @testing-library/react to include AppProvider for access to theme.